### PR TITLE
Update references to CRA terms to vite terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 node_modules
 dist
 .idea
-build
-build-*
+dist
+dist-*
 **/public/env.js
 
 # src/**/*.js

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn add vite-inject-env --dev
 - Add the following to `index.html`
 
 ```html
-<script src='/env.js'></script>
+<script type='module' src='/env.js'></script>
 ```
 
 - Create a new file called `env.js` and copy the following code:
@@ -43,7 +43,7 @@ export const App = () => {
 
 ### 3. Build your static files
 
-If you are using `create-react-app`, the command should be `npm run build` or `react-scripts build`.
+If you are using `vite`, the command should be `npm run build` or `vite build`.
 
 ### 4. Inject environment variables
 
@@ -66,7 +66,7 @@ set VITE_COLOR=navy&& set VITE_MAIN_TEXT=Navy Background&& npx vite-inject-env s
 
 ### Additional options
 
-`-d / --dir`: The location of your static build folder. Defaults to `./build`
+`-d / --dir`: The location of your static build folder. Defaults to `./dist`
 
 `-n / --name`: The name of the env file that is outputted. Defaults to `env.js`
 
@@ -101,7 +101,7 @@ export const env: EnvType = { ...import.meta.env, ...window.env }
 
 ## Docker / CICD
 
-`npx-react-env` works well with both Docker and CI/CD. 
+`vite-inject-env` works well with both Docker and CI/CD. 
 
 [Sample usage with Docker](./sample/v2/README.md#Docker)
 
@@ -115,7 +115,7 @@ RUN npm run build
 
 EXPOSE 8080
 
-ENTRYPOINT npx vite-inject-env set && npx http-server build
+ENTRYPOINT npx vite-inject-env set && npx http-server dist
 ```
 
 ```shell
@@ -156,6 +156,6 @@ There have been a few workarounds, with the most common solution being to load e
 
 ### Compatibility
 
-`vite-inject-env` was built with support for both `create-react-app` and `dotenv`. 
+`vite-inject-env` was built with support for both `vite` and `dotenv`. 
 
 However due to the simplicity of it, it should work with almost all scripts and tools.

--- a/sample/v2/Dockerfile
+++ b/sample/v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10-slim
+FROM node:18
 COPY . /app
 WORKDIR /app
 

--- a/sample/v2/Dockerfile
+++ b/sample/v2/Dockerfile
@@ -7,4 +7,4 @@ RUN npm run build
 
 EXPOSE 8080
 
-ENTRYPOINT npx vite-inject-env set && npx http-server build
+ENTRYPOINT npx vite-inject-env set && npx http-server dist

--- a/sample/v2/README.md
+++ b/sample/v2/README.md
@@ -26,7 +26,7 @@ set VITE_COLOR=navy&& set VITE_LOGO_URL=https://i.imgur.com/RAylUAO.png&& set VI
 ## 3. Serve
 
 ```
-npx http-server build 
+npx http-server dist
 ```
 
 ## 4. Change variables and re-serve

--- a/sample/v2/README.md
+++ b/sample/v2/README.md
@@ -38,7 +38,7 @@ VITE_COLOR=purple \
 VITE_LOGO_URL=https://i.imgur.com/RAylUAO.png \
 VITE_MAIN_TEXT="Insert Text here" \
 VITE_LINK_URL=https://my.link \
-npx vite-inject-env set && npx http-server build
+npx vite-inject-env set && npx http-server dist
 ```
 
 ## 5. Usage with dotenv
@@ -55,7 +55,7 @@ VITE_LINK_URL = https://my.link
 Then run the following command:
 
 ```
-npx vite-inject-env set && npx http-server build
+npx vite-inject-env set && npx http-server dist
 ```
 
 Note: Environment variables passed from the command line will always overwrite `.env` variables

--- a/sample/v2/README.md
+++ b/sample/v2/README.md
@@ -3,13 +3,14 @@
 You may run the following commands to test out this project:
 
 ## 1. Build
-```
+
+```sh
 npm run build
 ```
 
 ## 2. Set Environment Variables
 
-```
+```sh
 VITE_COLOR=navy VITE_LOGO_URL=https://i.imgur.com/RAylUAO.png VITE_MAIN_TEXT=vite-inject-env VITE_LINK_URL=https://www.npmjs.com/package/vite-inject-env npx vite-inject-env set
 
 # Formatted
@@ -25,7 +26,7 @@ set VITE_COLOR=navy&& set VITE_LOGO_URL=https://i.imgur.com/RAylUAO.png&& set VI
 
 ## 3. Serve
 
-```
+```sh
 npx http-server dist
 ```
 
@@ -33,7 +34,7 @@ npx http-server dist
 
 Try changing some variables and re-run step #2 and step #3.
 
-```
+```sh
 VITE_COLOR=purple \
 VITE_LOGO_URL=https://i.imgur.com/RAylUAO.png \
 VITE_MAIN_TEXT="Insert Text here" \
@@ -45,7 +46,7 @@ npx vite-inject-env set && npx http-server dist
 
 You may also use variables from dotenv. Create a `.env` file at `sample/v2/.env` and paste the following variables:
 
-```
+```js
 VITE_COLOR = black
 VITE_LOGO_URL = https://c.tenor.com/tIgmDpBGuKQAAAAd/kim-petras-i-love-you.gif
 VITE_MAIN_TEXT = Text from .env
@@ -54,23 +55,23 @@ VITE_LINK_URL = https://my.link
 
 Then run the following command:
 
-```
+```sh
 npx vite-inject-env set && npx http-server dist
 ```
 
 Note: Environment variables passed from the command line will always overwrite `.env` variables
 
-# Docker
+## Docker
 
 Build the Docker image
 
-```
+```sh
 docker build . -t vite-inject-env-sample-v2
 ```
 
 Run with environment variables
 
-```
+```sh
 docker run -p 8080:8080 \                   
 -e VITE_COLOR=yellow \
 -e VITE_LOGO_URL=./logo512.png \

--- a/sample/v2/index.html
+++ b/sample/v2/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Web site created using vite"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <!--
@@ -15,16 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>Vite App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/sample/v2/package.json
+++ b/sample/v2/package.json
@@ -3,27 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "cra-template": "1.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3"
   },
   "devDependencies": {
+    "vite": "^5.4.11",
     "http-server": "^13.0.2",
     "vite-inject-env": "^2.0.0"
   },
   "scripts": {
-    "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
-    "start:win": "set SKIP_PREFLIGHT_CHECK=true && react-scripts start",
-    "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "build:win": "set SKIP_PREFLIGHT_CHECK=true && react-scripts build",
-    "serve": "http-server build"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "start": "vite -l info",
+    "build": "vite build",
+    "preview": "vite preview",
+    "serve": "http-server dist"
   },
   "browserslist": {
     "production": [

--- a/sample/v2/public/index.html
+++ b/sample/v2/public/index.html
@@ -2,20 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <script src='%PUBLIC_URL%/env.js'></script>
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -30,6 +29,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="/env.js"></script>
+    <script type="module" src="/src/index.jsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/sample/v2/public/manifest.json
+++ b/sample/v2/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Vite App",
+  "name": "Vite App Sample",
   "icons": [
     {
       "src": "favicon.ico",

--- a/sample/v2/src/env.js
+++ b/sample/v2/src/env.js
@@ -1,1 +1,1 @@
-export const env = { ...process.env, ...window.env }
+export const env = { ...import.meta.env, ...window["env"] }

--- a/sample/v2/src/env2.ts
+++ b/sample/v2/src/env2.ts
@@ -1,12 +1,7 @@
-declare global {
-  interface Window {
-    env: any
-  }
-}
 type EnvType = {
   VITE_COLOR: string,
   VITE_MAIN_TEXT: string,
   VITE_LINK_URL: string,
   VITE_LOGO_URL: string
 }
-export const env: EnvType = { ...process.env, ...window.env }
+export const env: EnvType = { ...import.meta.env, ...window.env }

--- a/sample/v2/src/env2.ts
+++ b/sample/v2/src/env2.ts
@@ -1,3 +1,8 @@
+declare global {
+  interface Window {
+    env: any
+  }
+}
 type EnvType = {
   VITE_COLOR: string,
   VITE_MAIN_TEXT: string,

--- a/src/InjectEnv.ts
+++ b/src/InjectEnv.ts
@@ -8,7 +8,7 @@ export class InjectEnvCommandLine extends CommandLineParser {
   public constructor() {
     super({
       toolFilename: Cfg.NAME,
-      toolDescription: 'This tool is used to inject environment variables into your react /build folder.'
+      toolDescription: 'This tool is used to inject environment variables into your vite /dist folder.'
     })
 
     this.addAction(new BuildAction())

--- a/src/actions/SetAction.ts
+++ b/src/actions/SetAction.ts
@@ -5,14 +5,14 @@ import { retrieveDotEnvCfg, retrieveReactEnvCfg } from '../utils/Utils'
 export class SetAction extends CommandLineAction {
   private _dir!: CommandLineStringParameter
   get dir(): string {
-    // --dir has a default value of 'build'
+    // --dir has a default value of 'dist'
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this._dir.value!
   }
 
   private _fileName!: CommandLineStringParameter
   get fileName(): string {
-    // --dir has a default value of 'build'
+    // --dir has a default value of 'dist'
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this._fileName.value!
   }
@@ -26,11 +26,11 @@ export class SetAction extends CommandLineAction {
 
   protected onDefineParameters(): void {
     this._dir = this.defineStringParameter({
-      description: 'Specify the location of your build folder',
+      description: 'Specify the location of your dist folder',
       parameterLongName: '--dir',
       parameterShortName: '-d',
       argumentName: 'PATH_TO_BUILD_FOLDER',
-      defaultValue: './build',
+      defaultValue: './dist',
       required: false
     })
 
@@ -56,7 +56,7 @@ export class SetAction extends CommandLineAction {
   public constructor() {
     super({
       actionName: 'set',
-      summary: 'Set environment variables into your React /build folder.',
+      summary: 'Set environment variables into your React /dist folder.',
       documentation: 'TODO'
     })
   }

--- a/src/actions/SetAction.ts
+++ b/src/actions/SetAction.ts
@@ -56,7 +56,7 @@ export class SetAction extends CommandLineAction {
   public constructor() {
     super({
       actionName: 'set',
-      summary: 'Set environment variables into your React /dist folder.',
+      summary: 'Set environment variables into your Vite /dist folder.',
       documentation: 'TODO'
     })
   }

--- a/src/utils/File.ts
+++ b/src/utils/File.ts
@@ -46,7 +46,7 @@ export function replaceFilesInDir(dir: string) {
 }
 
 export function outputEnvFile(folder: string, fileName: string, envCfg: Record<string, string>, varName: string) {
-  shell.mkdir('-p', './build')
+  shell.mkdir('-p', `./${folder}`)
   console.info('Setting the following environment variables:')
   console.info(envCfg)
   writeFileSync(`${folder}/${fileName}`, `window.${varName} = ${JSON.stringify(envCfg, null, 2)}`)


### PR DESCRIPTION
Updated the following references:
- CRA -> Vite
- /build -> /dist (/dist is the default build output folder for vite. i understand this is a breaking change, but it'll make integration for a *new* vite app much easier)
- process.env -> import.meta.env (i did not touch the `env.ts` source code because I'm afraid of breaking it)
- %PUBLIC_URL% -> nothing (See [the docs](https://v2.vitejs.dev/guide/assets.html#the-public-directory) about this)

Also did the following:
- fixed a couple typos and fail references
- Updated readme to comply with markdown standards
- Updated v2 sample to be a valid vite app. Including updating the package.json

As a side note: the `build.yml` pipeline is like.. super outdated. checkout@v1, node 12, etc are not supported anymore by GH actions.